### PR TITLE
Feature jrickard registry source variable

### DIFF
--- a/collector/tools/dev.sh
+++ b/collector/tools/dev.sh
@@ -10,7 +10,7 @@ sudo podman run -it --rm --pull always \
     --workdir /root/koffer --entrypoint bash \
     --volume ${HOME}/.docker:/root/.docker:ro \
     --volume ${HOME}/.gitconfig:/root/.gitconfig:z \
-  docker.io/codesparta/koffer:latest
+  quay.io/codesparta/koffer:latest
 
 #   --volume ${HOME}/.aws:/root/.aws:z \
 #   --volume ${HOME}/.docker:/root/.docker:z \

--- a/collector/vars/global.yml
+++ b/collector/vars/global.yml
@@ -36,7 +36,7 @@ remote_home: "{{ ansible_env.HOME }}"
 #Source Registry
 # If quay.io source_repository = cloudctl ; if docker.io source_repository = library
 source_registry: quay.io
-source_repo: cloudctl
+source_repository: cloudctl
 
 # Docker Pull Secrets
 registry_quay_auth_file: "{{ dir_secrets }}/docker/quay.json }}"

--- a/collector/vars/global.yml
+++ b/collector/vars/global.yml
@@ -33,6 +33,11 @@ tf_vars: "{{ dir_iac }}/global.tfvars"
 local_user: "{{ lookup('env', 'USER') }}"
 remote_home: "{{ ansible_env.HOME }}"
 
+#Source Registry
+# If quay.io source_repository = cloudctl ; if docker.io source_repository = library
+source_registry: quay.io
+source_repo: cloudctl
+
 # Docker Pull Secrets
 registry_quay_auth_file: "{{ dir_secrets }}/docker/quay.json }}"
 registry_mirror_auth_file: "{{ dir_secrets }}/docker/mirror.json }}"

--- a/collector/vars/images.yml
+++ b/collector/vars/images.yml
@@ -10,24 +10,23 @@ images_pause:
     path: "{{ dir_platform }}/images"
 
 images_cloudctl:
-  - uri: "{{ (source_registry == 'quay.io') | ternary('quay.io', 'docker.io') }}/{{ (source_registry == 'quay.io') | ternary('cloudctl', 'library') }}"
-    #- uri: "{{ source_registry | default('quay.io') }}/{{ source_repository | default('cloudctl') }}"
+  - uri: "{{ (source_registry == 'quay.io') | ternary('quay.io', 'docker.io') }}/{{ source_repository | default('cloudctl') }}"
     name: konductor
     tag: "{{ konductor_version | default( tpdk_version ) }}"
     path: "{{ dir_platform }}/images"
-  - uri: "{{ source_registry | default('quay.io') }}/{{ source_repository | default('cloudctl') }}"
+  - uri: "{{ (source_registry == 'quay.io') | ternary('quay.io', 'docker.io') }}/{{ source_repository | default('cloudctl') }}"
     name: nginx
     tag: latest
     path: "{{ dir_platform }}/images"
-  - uri: "{{ source_registry | default('quay.io') }}/{{ source_repository | default('cloudctl') }}"
+  - uri: "{{ (source_registry == 'quay.io') | ternary('quay.io', 'docker.io') }}/{{ source_repository | default('cloudctl') }}"
     name: registry
     tag: latest
     path: "{{ dir_platform }}/images"
-  - uri: "{{ source_registry | default('quay.io') }}/{{ source_repository | default('cloudctl') }}"
+  - uri: "{{ (source_registry == 'quay.io') | ternary('quay.io', 'docker.io') }}/{{ source_repository | default('cloudctl') }}"
     name: coredns
     tag: latest
     path: "{{ dir_platform }}/images"
-  - uri: "{{ source_registry | default('quay.io') }}/{{ source_repository | default('cloudctl') }}"
+  - uri: "{{ (source_registry == 'quay.io') | ternary('quay.io', 'docker.io') }}/{{ source_repository | default('cloudctl') }}"
     name: haproxy
     tag: latest
     path: "{{ dir_platform }}/images"

--- a/collector/vars/images.yml
+++ b/collector/vars/images.yml
@@ -14,10 +14,6 @@ images_cloudctl:
     name: konductor
     tag: "{{ konductor_version | default( tpdk_version ) }}"
     path: "{{ dir_platform }}/images"
-  - uri: docker.io
-    name: busybox
-    tag: latest
-    path: "{{ dir_platform }}/images"
   - uri: "{{ source_registry | default('quay.io') }}/{{ source_repository | default('cloudctl') }}"
     name: nginx
     tag: latest

--- a/collector/vars/images.yml
+++ b/collector/vars/images.yml
@@ -10,7 +10,8 @@ images_pause:
     path: "{{ dir_platform }}/images"
 
 images_cloudctl:
-  - uri: "{{ source_registry | default('quay.io') }}/{{ source_repository | default('cloudctl') }}"
+  - uri: "{{ (source_registry == 'quay.io') | ternary('quay.io', 'docker.io') }}/{{ (source_registry == 'quay.io') | ternary('cloudctl', 'library') }}"
+    #- uri: "{{ source_registry | default('quay.io') }}/{{ source_repository | default('cloudctl') }}"
     name: konductor
     tag: "{{ konductor_version | default( tpdk_version ) }}"
     path: "{{ dir_platform }}/images"

--- a/collector/vars/images.yml
+++ b/collector/vars/images.yml
@@ -10,27 +10,27 @@ images_pause:
     path: "{{ dir_platform }}/images"
 
 images_cloudctl:
-  - uri: "{{ source_registry | default('quay.io') }}/{{ source_repository | default('codectl') }}"
+  - uri: "{{ source_registry | default('quay.io') }}/{{ source_repository | default('cloudctl') }}"
     name: konductor
     tag: "{{ konductor_version | default( tpdk_version ) }}"
     path: "{{ dir_platform }}/images"
-  - uri: "{{ source_registry | default('docker.io') }}/{{ source_repository | default('library') }}"
+  - uri: docker.io
     name: busybox
     tag: latest
     path: "{{ dir_platform }}/images"
-  - uri: "{{ source_registry | default('quay.io') }}/{{ source_repository | default('codectl') }}"
+  - uri: "{{ source_registry | default('quay.io') }}/{{ source_repository | default('cloudctl') }}"
     name: nginx
     tag: latest
     path: "{{ dir_platform }}/images"
-  - uri: "{{ source_registry | default('quay.io') }}/{{ source_repository | default('codectl') }}"
+  - uri: "{{ source_registry | default('quay.io') }}/{{ source_repository | default('cloudctl') }}"
     name: registry
     tag: latest
     path: "{{ dir_platform }}/images"
-  - uri: "{{ source_registry | default('quay.io') }}/{{ source_repository | default('codectl') }}"
+  - uri: "{{ source_registry | default('quay.io') }}/{{ source_repository | default('cloudctl') }}"
     name: coredns
     tag: latest
     path: "{{ dir_platform }}/images"
-  - uri: "{{ source_registry | default('quay.io') }}/{{ source_repository | default('codectl') }}"
+  - uri: "{{ source_registry | default('quay.io') }}/{{ source_repository | default('cloudctl') }}"
     name: haproxy
     tag: latest
     path: "{{ dir_platform }}/images"

--- a/collector/vars/images.yml
+++ b/collector/vars/images.yml
@@ -10,19 +10,27 @@ images_pause:
     path: "{{ dir_platform }}/images"
 
 images_cloudctl:
-  - uri: "docker.io/cloudctl"
+  - uri: "{{ source_registry | default('quay.io') }}/{{ source_repository | default('codectl') }}"
     name: konductor
     tag: "{{ konductor_version | default( tpdk_version ) }}"
     path: "{{ dir_platform }}/images"
-  - uri: "docker.io/library"
+  - uri: "{{ source_registry | default('docker.io') }}/{{ source_repository | default('library') }}"
     name: busybox
     tag: latest
     path: "{{ dir_platform }}/images"
-  - uri: "docker.io/library"
+  - uri: "{{ source_registry | default('quay.io') }}/{{ source_repository | default('codectl') }}"
     name: nginx
     tag: latest
     path: "{{ dir_platform }}/images"
-  - uri: "docker.io/cloudctl"
+  - uri: "{{ source_registry | default('quay.io') }}/{{ source_repository | default('codectl') }}"
     name: registry
+    tag: latest
+    path: "{{ dir_platform }}/images"
+  - uri: "{{ source_registry | default('quay.io') }}/{{ source_repository | default('codectl') }}"
+    name: coredns
+    tag: latest
+    path: "{{ dir_platform }}/images"
+  - uri: "{{ source_registry | default('quay.io') }}/{{ source_repository | default('codectl') }}"
+    name: haproxy
     tag: latest
     path: "{{ dir_platform }}/images"


### PR DESCRIPTION
This PR fixes #10 .

vars/global.yml was updated with two variables
source_registry
source_repository

images.yml uri was updated with:
```yaml
{{ ( source_registry == 'quay.io') | ternary('quay.io', 'docker.io') }}
```